### PR TITLE
fix: quote all args that desperately  need quotes

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 name: kube-downscaler
 description: A Helm chart for kube-downscaler
-home: https://github.com/hjacobs/kube-downscaler
+home: https://codeberg.org/hjacobs/kube-downscaler
 
 type: application
 
-version: 0.1.0
+version: 0.1.1
 
-appVersion: 20.4.3
+appVersion: 20.10.0
 
 dependencies:
   - name: common

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -35,19 +35,19 @@ args:
 - --include-resources={{ . | join "," }}
 {{- end }}
 {{- with $deployment.gracePeriod }}
-- --grace-period={{ . }}
+- --grace-period={{ . | quote }}
 {{- end }}
 {{- with $deployment.upscalePeriod }}
-- --upscale-period={{ . }}
+- --upscale-period={{ . | quote }}
 {{- end }}
 {{- with $deployment.downscalePeriod }}
-- --downscale-period={{ . }}
+- --downscale-period={{ . | quote }}
 {{- end }}
 {{- with $deployment.defaultUptime }}
-- --default-uptime={{ . }}
+- --default-uptime={{ . | quote }}
 {{- end }}
 {{- with $deployment.defaultDowntime }}
-- --default-downtime={{ . }}
+- --default-downtime={{ . | quote }}
 {{- end }}
 {{- with $deployment.excludeDeployments | join "," }}
 - --exclude-deployments={{ . }}
@@ -56,6 +56,6 @@ args:
 - --downtime-replicas={{ . }}
 {{- end }}
 {{- with $deployment.deploymentTimeAnnotation }}
-- --deployment-time-annotation={{ . }}
+- --deployment-time-annotation={{ . | quote }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
Passing arguments without quotes would makes Python fail to parse and cause errors.